### PR TITLE
refactor: utils package

### DIFF
--- a/pkg/utils/lang.go
+++ b/pkg/utils/lang.go
@@ -32,14 +32,6 @@ func ContainsString(list []string, s string) bool {
 	return false
 }
 
-func Abs(x int) int {
-	if x < 0 {
-		return -x
-	}
-
-	return x
-}
-
 func IsNumber(x interface{}) bool {
 	kind := reflect.TypeOf(x).Kind()
 	return kind >= 2 && kind <= 16

--- a/pkg/utils/lang.go
+++ b/pkg/utils/lang.go
@@ -3,10 +3,10 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"reflect"
-	"sort"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // Omit returns a copy of the given map with the given keys left out
@@ -79,21 +79,6 @@ func Min(x, y int) int {
 	}
 
 	return y
-}
-
-func SortMap(unsortedMap map[string]interface{}) map[string]interface{} {
-	keys := make([]string, 0, len(unsortedMap))
-	for k := range unsortedMap {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	sortedMap := make(map[string]interface{})
-	for _, k := range keys {
-		sortedMap[k] = unsortedMap[k]
-	}
-
-	return sortedMap
 }
 
 func DefaultContext() (context.Context, context.CancelFunc) {

--- a/pkg/utils/lang.go
+++ b/pkg/utils/lang.go
@@ -96,10 +96,6 @@ func SortMap(unsortedMap map[string]interface{}) map[string]interface{} {
 	return sortedMap
 }
 
-func TimeFormat() string {
-	return "2006-01-02T15:04:05.999999999"
-}
-
 func DefaultContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), time.Second*30)
 }

--- a/pkg/utils/lang.go
+++ b/pkg/utils/lang.go
@@ -14,15 +14,7 @@ func Omit(value map[string]string, ignoredKeys ...string) map[string]string {
 	copy := make(map[string]string, len(value))
 
 	for k, v := range value {
-		ignored := false
-
-		for _, ignoredKey := range ignoredKeys {
-			if k == ignoredKey {
-				ignored = true
-			}
-		}
-
-		if !ignored {
+		if !ContainsString(ignoredKeys, k) {
 			copy[k] = v
 		}
 


### PR DESCRIPTION
* removes `utils.TimeFormat`, to use std. time.RFC3339Nano instead
* drops `utils.SortMap`, as it is ineffective
* refactors `utils.Omit` to use `ContainsString`
* drops `utils.Abs` to prefer `math.Abs`

TODO:
- [X] Manual Testing (or with unit tests) [see #2]

ESSNTL-4192