### PR TITLE
ci: Add GitHub actions for linting Go code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Lint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint-code:
+    name: Lint code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Updating ...
+        run: sudo apt-get -qq update
+
+      - name: Set up go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.18"
+          cache: false
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: "latest"
+          args: "--verbose --timeout 5m"
+
+  lint-language:
+    name: Lint language
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Run woke
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: false

--- a/pkg/avro/types.go
+++ b/pkg/avro/types.go
@@ -88,8 +88,7 @@ func (t *TypeWrapper) UnmarshalJSON(typeBytes []byte) (err error) {
 	err = json.Unmarshal(typeBytes, &typeString)
 
 	if err == nil {
-		var typeObj Type
-		typeObj = Type{
+		var typeObj = Type{
 			Type: typeString,
 		}
 		*t = []Type{typeObj}


### PR DESCRIPTION
This patch adds actions to lint Go code with `golangci-lint`, and fixes all the issues returned by this tool. It also includes tooling to detect non-inclusive language in the source code. Note that is non voting for now.